### PR TITLE
Add license in package.json

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -1,4 +1,5 @@
-{
+{  
+  "license": "CC BY 4.0",
   "scripts": {
     "examples": "docusaurus-examples",
     "start": "docusaurus-start",


### PR DESCRIPTION
to silence warning when building

I put Creative Commons Attribution 4.0 International, another could be chosen

You could also add in repository a file name LICENSE.md or LICENSE or LICENSE-docs which contains :
https://github.com/4d/4d-for-ios/blob/master/LICENSE-docs