### PR TITLE
fix: do not ignore yarn.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ lib/core/MetadataBlog.js
 
 website/translated_docs
 website/build/
-website/yarn.lock
 website/node_modules
 !website/node_modules/highlight.js/lib/index.js
 !website/node_modules/highlight.js/lib/languages/code4d.js


### PR DESCRIPTION
The `yarn.lock` file should not be ignored in the Git repo.
It is essential for Yarn to have this file to reproduce the build with the exact same dependencies.

See the official docs https://classic.yarnpkg.com/en/docs/yarn-lock/