### PR TITLE
Update parameters.md

### DIFF
--- a/docs/Concepts/parameters.md
+++ b/docs/Concepts/parameters.md
@@ -162,7 +162,7 @@ C_TEXT($1;$2;$3;$4;$5;$6)
 The $0 parameter (Longint), which is the result of a trigger, will be typed by the compiler if the parameter has not been explicitly declared. Nevertheless, if you want to declare it, you must do so in the trigger itself.
 
 - Form objects that accept the `On Drag Over` form event
-The $0 parameter (Longint), which is the result of the `On Drag Over` form event, is typed by the compiler if the parameter has not been explicitly declared. Nevertheless, if you want to decalre it, you must do so in the object method.
+The $0 parameter (Longint), which is the result of the `On Drag Over` form event, is typed by the compiler if the parameter has not been explicitly declared. Nevertheless, if you want to declare it, you must do so in the object method.
 **Note:** The compiler does not initialize the $0 parameter. So, as soon as you use the `On Drag Over` form event, you must initialize $0. For example:
 ```4d
  C_LONGINT($0)


### PR DESCRIPTION
There was a minor typo: "Nevertheless, if you want to [decalre] it, you must do so in the object method," which is under the "Declaring parameters" section. Just change it to "declare."